### PR TITLE
fix: use metrics store as source of truth for flagged filter counts

### DIFF
--- a/src/components/QuestionFiltersBar.tsx
+++ b/src/components/QuestionFiltersBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { QuestionFilter } from "@/types/quiz";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { calculateMetrics, initializeMetrics } from "@/utils/metricsUtils";
+import { calculateMetrics, initializeMetrics, isQuestionFlagged } from "@/utils/metricsUtils";
 
 type FilterCategory = {
   label: string;
@@ -133,7 +133,8 @@ const QuestionFiltersBar = ({ filters, onToggleFilter, questions }: QuestionFilt
           counts.incorrect++;
         }
       }
-      if (q.isFlagged) {
+      // Use metrics store for flagged state
+      if (isQuestionFlagged(q.id)) {
         counts.flagged++;
       }
     });

--- a/src/components/qbanks/QuestionLibrary.tsx
+++ b/src/components/qbanks/QuestionLibrary.tsx
@@ -1,4 +1,3 @@
-
 import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -21,7 +20,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import MediaSelector from "./MediaSelector";
-import { updateQuestionMetrics, initializeMetrics } from "@/utils/metricsUtils";
+import { updateQuestionMetrics, initializeMetrics, removeQuestionMetrics } from "@/utils/metricsUtils";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -350,7 +349,7 @@ const QuestionLibrary = ({ qbanks }: QuestionLibraryProps) => {
           .filter(row => row && row.length >= 2)
           .map((row: any) => {
             const [question, correctAnswer, otherChoices, category, explanation] = row;
-            
+
             // Modified tag handling to support semicolon-separated tags
             let tags: string[] = ['general'];
             if (category?.toString().trim()) {
@@ -359,7 +358,7 @@ const QuestionLibrary = ({ qbanks }: QuestionLibraryProps) => {
                 .split(';')
                 .map(tag => tag.toLowerCase().trim())
                 .filter(Boolean);
-              
+
               // If after filtering we have no valid tags, use 'general'
               if (tags.length === 0) {
                 tags = ['general'];
@@ -470,6 +469,9 @@ const QuestionLibrary = ({ qbanks }: QuestionLibraryProps) => {
       qbank.questions = qbank.questions.filter(q => !questionIds.includes(q.id));
     });
 
+    // Remove metrics for deleted questions
+    questionIds.forEach(id => removeQuestionMetrics(id));
+
     removeEmptyQBanks(); // Remove tags/qbanks with no questions
 
     saveQBanksToStorage();
@@ -492,6 +494,9 @@ const QuestionLibrary = ({ qbanks }: QuestionLibraryProps) => {
         qbank.questions.splice(index, 1);
       }
     });
+
+    // Remove metrics for deleted question
+    removeQuestionMetrics(questionId);
 
     removeEmptyQBanks(); // Remove tags/qbanks with no questions
 

--- a/src/hooks/quiz/useQuiz.ts
+++ b/src/hooks/quiz/useQuiz.ts
@@ -43,11 +43,10 @@ export const useQuiz = ({ onQuizComplete, onQuizStart, onQuizEnd }: UseQuizProps
       }
     }
 
-    // Reset attempts and flags for all selected questions before starting quiz
+    // Reset attempts for all selected questions before starting quiz
     selectedQuestions = selectedQuestions.map(q => ({
       ...q,
-      attempts: [],
-      isFlagged: false
+      attempts: []
     }));
 
     // Randomize the answer options for each question


### PR DESCRIPTION
- Updated QuestionFiltersBar to use the isQuestionFlagged helper from metricsUtils for flagged counts.
- Ensures the flagged filter and count always reflect the metrics store, not the question object.
- Lays groundwork for consistent flag state across navigation, filtering, and UI.