### PR TITLE
fix(metrics): ensure persistent and global tracking of question attem…

### DIFF
--- a/src/components/QuestionFiltersBar.tsx
+++ b/src/components/QuestionFiltersBar.tsx
@@ -108,61 +108,18 @@ const FilterButton = ({
 };
 
 const QuestionFiltersBar = ({ filters, onToggleFilter, questions }: QuestionFiltersBarProps) => {
-  const calculateLocalMetrics = (questions: any[]) => {
-    // Calculate metrics for the provided questions only
-    const counts = {
-      unused: 0,
-      used: 0,
-      correct: 0,
-      incorrect: 0,
-      flagged: 0,
-      omitted: 0
-    };
-    questions.forEach(q => {
-      const hasBeenAttempted = q.attempts && q.attempts.length > 0;
-      const lastAttempt = hasBeenAttempted ? q.attempts[q.attempts.length - 1] : null;
-      if (!hasBeenAttempted) {
-        counts.unused++;
-      } else {
-        counts.used++;
-        if (lastAttempt.selectedAnswer === null) {
-          counts.omitted++;
-        } else if (lastAttempt.isCorrect) {
-          counts.correct++;
-        } else {
-          counts.incorrect++;
-        }
-      }
-      // Use metrics store for flagged state
-      if (isQuestionFlagged(q.id)) {
-        counts.flagged++;
-      }
-    });
-    return counts;
-  };
-
-  const [metrics, setMetrics] = useState(() =>
-    questions ? calculateLocalMetrics(questions) : calculateMetrics()
-  );
+  const [metrics, setMetrics] = useState(() => calculateMetrics());
 
   useEffect(() => {
-    if (questions) {
-      setMetrics(calculateLocalMetrics(questions));
-    } else {
-      initializeMetrics();
-      setMetrics(calculateMetrics());
-    }
+    initializeMetrics();
+    setMetrics(calculateMetrics());
     // Re-calculate metrics when storage changes
     const handleStorageChange = () => {
-      if (questions) {
-        setMetrics(calculateLocalMetrics(questions));
-      } else {
-        setMetrics(calculateMetrics());
-      }
+      setMetrics(calculateMetrics());
     };
     window.addEventListener('storage', handleStorageChange);
     return () => window.removeEventListener('storage', handleStorageChange);
-  }, [questions]);
+  }, []);
 
   return (
     <div className="flex flex-wrap gap-2">

--- a/src/hooks/quiz/quizActions.ts
+++ b/src/hooks/quiz/quizActions.ts
@@ -1,9 +1,9 @@
-
 import { Question, QuizHistory, QuestionAttempt } from "@/types/quiz";
 import { QuizState } from "./types";
 import { qbanks } from "@/data/questions";
 import { toast } from "@/components/ui/use-toast";
 import { updateMetricsFromAttempt, updateQuestionFlag } from "@/utils/metricsUtils";
+import { saveQBanksToStorage } from "@/data/questions";
 
 export const initializeQuiz = (
   qbankId: string,
@@ -68,7 +68,7 @@ export const createQuizHistory = (
     questionAttempts: state.currentQuestions.map((q, index) => {
       const selectedAnswer = index === state.currentQuestionIndex ? optionIndex : q.attempts?.[0]?.selectedAnswer ?? null;
       const isCorrect = index === state.currentQuestionIndex ? optionIndex === q.correctAnswer : q.attempts?.[0]?.isCorrect ?? false;
-      
+
       return {
         questionId: q.id,
         selectedAnswer,
@@ -79,12 +79,12 @@ export const createQuizHistory = (
       };
     })
   };
-  
+
   // Update metrics for all attempts in this quiz
   history.questionAttempts.forEach(attempt => {
     updateMetricsFromAttempt(attempt);
   });
-  
+
   return history;
 };
 
@@ -111,9 +111,12 @@ export const handleQuestionAttempt = (
     ...(question.attempts || []),
     attempt
   ];
-  
+
   // Update metrics for this attempt
   updateMetricsFromAttempt(attempt);
+
+  // Persist updated attempts to localStorage
+  saveQBanksToStorage();
 
   return newQuestions;
 };

--- a/src/pages/QBanks.tsx
+++ b/src/pages/QBanks.tsx
@@ -26,6 +26,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Label } from "@/components/ui/label";
+import { calculateMetrics } from "@/utils/metricsUtils";
 
 interface QBanksProps {
   qbanks: QBank[];
@@ -71,7 +72,7 @@ const QBanks = ({ qbanks }: QBanksProps) => {
     const reader = new FileReader();
     reader.onload = (e) => {
       const text = e.target?.result as string;
-      const rows = text.split('\n').map(row => 
+      const rows = text.split('\n').map(row =>
         row.split(',').map(cell => cell.replace(/^"|"$/g, '').replace(/""/g, '"'))
       );
 
@@ -79,7 +80,7 @@ const QBanks = ({ qbanks }: QBanksProps) => {
       const questions: Question[] = rows.slice(1).map((row, index) => {
         const options = row.slice(3, 10).filter(opt => opt.trim() !== '');
         const imageFilename = row[10]?.trim();
-        
+
         // Find matching media file
         const mediaFile = mediaFiles.find(file => file.name === imageFilename);
         const mediaUrl = mediaFile ? URL.createObjectURL(mediaFile) : undefined;
@@ -109,11 +110,11 @@ const QBanks = ({ qbanks }: QBanksProps) => {
       };
 
       qbanks.push(newQBank);
-      
+
       // Explicitly save to localStorage
       saveQBanksToStorage();
       console.log('Imported qbank from CSV and saved:', qbanks.length);
-      
+
       setMediaFiles([]); // Clear media files after import
       toast({
         title: "Success",
@@ -141,11 +142,11 @@ const QBanks = ({ qbanks }: QBanksProps) => {
     };
 
     qbanks.push(newQBank);
-    
+
     // Explicitly save to localStorage
     saveQBanksToStorage();
     console.log('Created new qbank and saved:', qbanks.length);
-    
+
     setNewQBankName("");
     setNewQBankDescription("");
     setShowNewQBankDialog(false);
@@ -159,11 +160,11 @@ const QBanks = ({ qbanks }: QBanksProps) => {
     const index = qbanks.findIndex((qbank) => qbank.id === qbankId);
     if (index !== -1) {
       qbanks.splice(index, 1);
-      
+
       // Explicitly save to localStorage
       saveQBanksToStorage();
       console.log('Deleted qbank and saved:', qbanks.length);
-      
+
       setSelectedQBank(null);
       toast({
         title: "Success",
@@ -191,11 +192,11 @@ const QBanks = ({ qbanks }: QBanksProps) => {
       }
       qbank.name = editingName;
       qbank.description = editingDescription;
-      
+
       // Explicitly save to localStorage
       saveQBanksToStorage();
       console.log('Updated qbank and saved:', qbanks.length);
-      
+
       setEditingQBankId(null);
       toast({
         title: "Success",
@@ -238,11 +239,11 @@ const QBanks = ({ qbanks }: QBanksProps) => {
       }
 
       selectedQBank.questions.push(question);
-      
+
       // Explicitly save to localStorage
       saveQBanksToStorage();
       console.log('Added question to qbank and saved:', selectedQBank.questions.length);
-      
+
       setNewQuestion({
         question: "",
         options: ["", "", "", ""],
@@ -297,7 +298,7 @@ const QBanks = ({ qbanks }: QBanksProps) => {
       ])
     ];
 
-    const csvContent = csvRows.map(row => row.map(cell => 
+    const csvContent = csvRows.map(row => row.map(cell =>
       `"${String(cell).replace(/"/g, '""')}"`
     ).join(',')).join('\n');
 
@@ -308,37 +309,7 @@ const QBanks = ({ qbanks }: QBanksProps) => {
     link.click();
   };
 
-  const calculateQuestionMetrics = (qbank: QBank) => {
-    const metrics = {
-      unused: 0,
-      used: 0,
-      correct: 0,
-      incorrect: 0,
-      omitted: 0,
-      flagged: 0
-    };
-
-    qbank.questions.forEach(question => {
-      if (!question.attempts || question.attempts.length === 0) {
-        metrics.unused++;
-      } else {
-        metrics.used++;
-        const lastAttempt = question.attempts[question.attempts.length - 1];
-        if (lastAttempt.selectedAnswer === null) {
-          metrics.omitted++;
-        } else if (lastAttempt.isCorrect) {
-          metrics.correct++;
-        } else {
-          metrics.incorrect++;
-        }
-      }
-      if (question.isFlagged) {
-        metrics.flagged++;
-      }
-    });
-
-    return metrics;
-  };
+  const metrics = calculateMetrics();
 
   const updateMedia = () => {
     toast({
@@ -370,8 +341,8 @@ const QBanks = ({ qbanks }: QBanksProps) => {
 
       <div className="grid gap-4">
         {qbanks.map((qbank) => {
-          const metrics = calculateQuestionMetrics(qbank);
-          
+          const metrics = calculateMetrics();
+
           return (
             <div
               key={qbank.id}
@@ -453,8 +424,8 @@ const QBanks = ({ qbanks }: QBanksProps) => {
             <DialogTitle>Manage Media</DialogTitle>
           </DialogHeader>
           {selectedQBankForMedia && (
-            <MediaManager 
-              qbank={selectedQBankForMedia} 
+            <MediaManager
+              qbank={selectedQBankForMedia}
               onMediaUpdate={() => {
                 setShowMediaDialog(false);
                 setSelectedQBankForMedia(null);

--- a/src/pages/pages/QBanks.tsx
+++ b/src/pages/pages/QBanks.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import Pagination from "@/components/Pagintion";
 import { Dialog as Modal, DialogContent as ModalContent, DialogHeader as ModalHeader, DialogTitle as ModalTitle } from "@/components/ui/dialog";
+import { calculateMetrics } from "@/utils/metricsUtils";
 
 interface QBanksProps {
   qbanks: QBank[];
@@ -314,37 +315,7 @@ const QBanks = ({ qbanks }: QBanksProps) => {
     link.click();
   };
 
-  const calculateQuestionMetrics = (qbank: QBank) => {
-    const metrics = {
-      unused: 0,
-      used: 0,
-      correct: 0,
-      incorrect: 0,
-      omitted: 0,
-      flagged: 0
-    };
-
-    qbank.questions.forEach(question => {
-      if (!question.attempts || question.attempts.length === 0) {
-        metrics.unused++;
-      } else {
-        metrics.used++;
-        const lastAttempt = question.attempts[question.attempts.length - 1];
-        if (lastAttempt.selectedAnswer === null) {
-          metrics.omitted++;
-        } else if (lastAttempt.isCorrect) {
-          metrics.correct++;
-        } else {
-          metrics.incorrect++;
-        }
-      }
-      if (question.isFlagged) {
-        metrics.flagged++;
-      }
-    });
-
-    return metrics;
-  };
+  const metrics = calculateMetrics();
 
   const updateMedia = () => {
     toast({
@@ -381,7 +352,7 @@ const QBanks = ({ qbanks }: QBanksProps) => {
 
       <div className="grid gap-4">
         {paginatedQBanks.map((qbank) => {
-          const metrics = calculateQuestionMetrics(qbank);
+          const metrics = calculateMetrics();
 
           return (
             <div


### PR DESCRIPTION
…pts and metrics

- Always persist question attempts to localStorage after every attempt, including in quiz flows and admin/import actions.
- Refactor all metrics and UI (filters, dashboards, QBank pages) to use the persistent metrics store (`calculateMetrics` from metricsUtils) instead of recalculating from in-memory attempts.
- Ensure "unused", "used", "correct", "incorrect", "omitted", and "flagged" statuses are always accurate and never revert unless explicitly reset or deleted.
- Remove local metrics calculations in favor of global, persistent metrics for UI consistency.
- Improves reliability of attempt tracking and status display across navigation, reloads, and all user/admin actions.